### PR TITLE
Add notice that this won't work for private repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Additionally you can set up maximum number of people to ping in the PR message, 
 mention.run(2, ["Pods/"], ["wojteklu"])
 ```
 
+## Caveats
+
+Unfortunately Github does not allow access to the blame route for private repositories. Therefore this plugin only works with public repos.
+
 ## License
 
 This project is licensed under the terms of the MIT license. See the LICENSE file.


### PR DESCRIPTION
This morning I tried to use this plugin for one private repository of my organziation. Since the plugin uses the html blame from Github it cannot be used with private repositories. See the discussion in facebook/mention-bot#8 as well.