### PR TITLE
Add note about the project using web-scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A [Danger](https://github.com/danger/danger) plugin to automatically mention potential reviewers on pull requests on GitHub and GitLab.
 
+**Note**: This plugin uses the web-scraping of GitHub.com and GitLab to detect the authors to find potential reviewers. This might cause the plugin to break if either of those pages introduce design changes.
+
 ## Installation
 
     $ gem install danger-mention


### PR DESCRIPTION
By using web scraping we're not actually looking at the full history, also it's very error prone, and probably something that we should get rid of and use local git features instead.