### PR TITLE
don't return nil values as reviewers

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -125,7 +125,7 @@ module Danger
       users = users.select { |k, _| !user_blacklist.include? k }
       users = users.sort_by { |_, value| value }.reverse
 
-      users[0...max_reviewers].map { |u| u[0] }
+      users[0...max_reviewers].map { |u| u[0] }.compact
     end
 
   end


### PR DESCRIPTION
to prevent following exception:
```
	from lib/danger_plugin.rb:53:in `block in run'
	from lib/danger_plugin.rb:53:in `map'
	from lib/danger_plugin.rb:53:in `run'
```

On some new repos this plugin would fail because it would not be able to detect reviewers and return nil values that can't be concatenated with strings to make the mention.